### PR TITLE
About form GitHub update patch 1

### DIFF
--- a/src/StartupManager/Pages/AboutForm.cs
+++ b/src/StartupManager/Pages/AboutForm.cs
@@ -13,7 +13,7 @@ using Utilities;
 
 public partial class AboutForm : Form
 {
-    private readonly GithubUpdateOperation _UpdateOperation = new();
+    private GithubUpdateOperation _UpdateOperation => GithubUpdateOperation.Instance;
 
     public AboutForm()
     {

--- a/src/StartupManager/Properties/CurrentVersionConstants.cs
+++ b/src/StartupManager/Properties/CurrentVersionConstants.cs
@@ -2,5 +2,5 @@
 
 internal static class CurrentVersionConstants
 {
-    internal const string VERSION = "1.0.0.0";
+    internal const string VERSION = "1.0.1.3";
 }


### PR DESCRIPTION
- Now accepts a versioning comparison instead of an equality check between versions.
- Github Update Operations is now a singleton, allowing persistence between opening the About form.
- Added an update check every 6 hours. This could be changed in the future to be a Settings variable but right now the need for varying update check time is not necessary
- Updates now allow for unreleased versions to be comparable to Live, allowing debug Update prompts if the unreleased version is lower than live. No update prompt is shown if ahead of live.