### PR TITLE
Build date responsiveness patch 1

### DIFF
--- a/src/StartupManager/Program.cs
+++ b/src/StartupManager/Program.cs
@@ -1,11 +1,12 @@
 ﻿namespace StartupManager;
 
 using System;
-using System.Diagnostics;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using Extensions;
+using Utilities;
 
-static class Program
+internal static class Program
 {
     /// <summary>
     /// The main entry point for the application.
@@ -22,6 +23,8 @@ static class Program
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(false);
         _ = new Start();
+        // This initializes the instance, otherwise it would only be initialized once used.
+        _ = Task.Run(() => GithubUpdateOperation.Instance);
         Application.Run();
         
     }

--- a/src/StartupManager/Utilities/GithubUpdateOperations.cs
+++ b/src/StartupManager/Utilities/GithubUpdateOperations.cs
@@ -7,14 +7,13 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using System.Windows.Forms;
 using Newtonsoft.Json.Linq;
 using Properties;
 using Timer = System.Timers.Timer;
 
 internal class GithubUpdateOperation
 {
-    internal static GithubUpdateOperation Instance { get; } = new();
+    internal static readonly GithubUpdateOperation Instance = new();
     private GithubUpdateOperation()
     {
         _UpdateTask = Task.Run(CheckForUpdate);
@@ -86,7 +85,6 @@ internal class GithubUpdateOperation
         {
             if (!await UpdateOperationAwaiter() || _CurrentVersion == null) return null;
             return DateTime.Parse(_CurrentVersion?["published_at"].ToString()).ToShortDateString();
-
         }
 
         if (!await UpdateOperationAwaiter()) return null;


### PR DESCRIPTION
Increases the responsiveness of the 'About' Form by implementing a background async check for the Github Update information instead of when used. The solution is early initialization over  on-demand initialization.